### PR TITLE
Fix Lua API script issues

### DIFF
--- a/scripts/api/entity/artifact.lua
+++ b/scripts/api/entity/artifact.lua
@@ -35,7 +35,7 @@ local Entity = getLuaEntityFunctionTable()
 --- Example: entity:setModel("artifact6")
 function Entity:setModel(model_name)
     for k, v in pairs(__model_data[model_name]) do
-        if string.sub(1, 2) ~= "__" then
+        if string.sub(k, 1, 2) ~= "__" then
             self.components[k] = table.deepcopy(v)
         end
     end

--- a/scripts/api/entity/cpuship.lua
+++ b/scripts/api/entity/cpuship.lua
@@ -94,7 +94,7 @@ end
 --- Give multiple ships the same entity and different offsets to create a formation.
 --- Example: ship:orderFlyFormation(leader, 500, 250) -- fly 0.5U off the wing and 0.25U off the tail of the entity `leader`
 function Entity:orderFlyFormation(target, offset_x, offset_y)
-    if self.components.ai_controller then self.components.ai_controller = {orders = "fly in formation", order_target=target, order_target_location={x, y}} end
+    if self.components.ai_controller then self.components.ai_controller = {orders = "fly in formation", order_target=target, order_target_location={offset_x, offset_y}} end
     return self
 end
 --- Orders this AI-controlled ship to move toward the given coordinates, and to attack hostiles that approach within its short-range radar range during transit.

--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -124,7 +124,7 @@ end
 --- Defaults to 0.
 --- Example: planet:setAxialRotationTime(20)
 function Entity:setAxialRotationTime(rotation_time)
-    if spin ~= 0.0 then
+    if rotation_time ~= 0.0 then
         self.components.spin = {rate=360.0/rotation_time}
     else
         self.components.spin = nil

--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -100,7 +100,7 @@ end
 --- If this value isn't larger than the Planet's radius, the cloud layer won't be visible.
 --- Example: planet:setPlanetCloudRadius(2500) -- sets this Planet's cloud radius to 2.5U
 function Entity:setPlanetCloudRadius(radius)
-    if self.planet_render then self.components.planet_render.cloud_size = radius end
+    if self.components.planet_render then self.components.planet_render.cloud_size = radius end
     return self
 end
 --- Sets the z-position of this Planet, the distance by which it's offset above (positive) or below (negative) the movement plane.

--- a/scripts/api/entity/planet.lua
+++ b/scripts/api/entity/planet.lua
@@ -120,9 +120,10 @@ function Entity:setDistanceFromMovementPlane(z)
     end
     return self
 end
---- Sets this Planet's axial rotation time, seconds per full rotation.
+--- Sets this entity's axial rotation time, in seconds per full rotation.
+--- This uses the Spin component.
 --- Defaults to 0.
---- Example: planet:setAxialRotationTime(20)
+--- Example: entity:setAxialRotationTime(20)
 function Entity:setAxialRotationTime(rotation_time)
     if rotation_time ~= 0.0 then
         self.components.spin = {rate=360.0/rotation_time}
@@ -132,7 +133,7 @@ function Entity:setAxialRotationTime(rotation_time)
     return self
 end
 --- Sets an entity around which this entity orbits, as well as its orbital period in seconds. Setting time to 0 will stop movement, while still being locked in orbit.
---- An orbit can be cancelled by setting the target to nil
+--- An orbit can be cancelled by setting the target to nil.
 --- Example:
 --- moon:setOrbit(planet, 20)
 --- moon:setOrbit(nil) -- undo orbiting

--- a/scripts/api/entity/playerspaceship.lua
+++ b/scripts/api/entity/playerspaceship.lua
@@ -128,7 +128,7 @@ end
 function Entity:isCommsBeingHailed()
     if self.components.comms_transmitter then
         local state = self.components.comms_transmitter.state
-        return state == "hailed" or state == "hailed_player" or state == "hailed_gm"
+        return state == "hailed" or state == "hailed_gm"
     end
 end
 --- Returns whether this ship is being hailed by the GM.

--- a/scripts/api/entity/scanprobe.lua
+++ b/scripts/api/entity/scanprobe.lua
@@ -27,7 +27,7 @@ function ScanProbe()
     if idx == 2 then model = "SensorBuoyMKII" end
     if idx == 3 then model = "SensorBuoyMKIII" end
     for k, v in pairs(__model_data[model]) do
-        if string.sub(1, 2) ~= "__" then
+        if string.sub(k, 1, 2) ~= "__" then
             e.components[k] = table.deepcopy(v)
         end
     end

--- a/scripts/api/entity/sciencedatabase.lua
+++ b/scripts/api/entity/sciencedatabase.lua
@@ -13,6 +13,7 @@ local Entity = getLuaEntityFunctionTable()
 --- Each ScienceDatabase entry has a unique identifier regardless of its displayed order, and multiple entries can have the same name.
 --- Changes to ScienceDatabases appear in the UI only after a player opens the Database or selects an entry.
 ---
+--- [NOT IMPLEMENTED YET]
 --- To retrieve a 1-indexed table of all parentless entries, use the global function getScienceDatabases().
 --- You can then use this class's functions to get child entries and entry data.
 ---
@@ -65,10 +66,10 @@ function Entity:addEntry(name)
     child.components.science_database.parent = self
     return child
 end
---- Returns the first child ScienceDatabase entry of this ScienceDatabase entry found with the given case-insensitive name.
+--- Returns the first child ScienceDatabase entry of this ScienceDatabase entry found with the given name.
 --- Multiple entries can have the same name.
 --- Returns nil if no entry is found.
---- Example: entry:getEntryByName("canines") -- returns the "Canines" entry in sdb
+--- Example: entry:getEntryByName("Canines") -- returns the "Canines" entry in sdb
 function Entity:getEntryByName(name)
     name = string.lower(name)
     for idx, e in ipairs(getEntitiesWithComponent("science_database")) do
@@ -77,6 +78,7 @@ function Entity:getEntryByName(name)
     return nil
 end
 --- Returns a 1-indexed table of all child entries in this ScienceDatabase entry, in arbitrary order.
+--- [NOT IMPLEMENTED YET]
 --- To return parentless top-level ScienceDatabase entries, use the global function getScienceDatabases().
 --- Examples:
 --- entry = getScienceDatabases()[1] -- returns the first parentless entry
@@ -91,7 +93,7 @@ end
 --- Returns true if this ScienceDatabase entry has child entries.
 --- Example: entry:hasEntries()
 function Entity:hasEntries()
-    return #getEntries() > 0
+    return #self:getEntries() > 0
 end
 --- Adds a key/value pair to this ScienceDatabase entry's key/value data.
 --- The Database view's center column displays all key/value data when its entry is selected.
@@ -213,7 +215,6 @@ function Entity:setModelDataName(model_data_name)
     end
     return self
 end
-
 
 --- ScienceDatabase queryScienceDatabase(...)
 --- Returns the first ScienceDatabase entry with a matching case-insensitive name within the ScienceDatabase hierarchy.

--- a/scripts/api/entity/sciencedatabase.lua
+++ b/scripts/api/entity/sciencedatabase.lua
@@ -209,7 +209,7 @@ end
 --- Example: entry:setModelDataName("AtlasHeavyFighterYellow") -- uses the ModelData named "AtlasHeavyFighterYellow"
 function Entity:setModelDataName(model_data_name)
     if __model_data[model_data_name] then
-        self.components.mesh_render = __model_data[model_data_name].mesh_render
+        self.components.mesh_render = table.deepcopy(__model_data[model_data_name].mesh_render)
     else
         self.components.mesh_render = nil
     end

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -205,13 +205,15 @@ end
 --- Sets the radar trace image for this entity.
 --- Valid values are filenames of PNG images relative to the resources/radar directory.
 --- Radar trace images should be white with a transparent background.
---- Only scanned ships use a specific radar trace image. Unscanned ships always display as an arrow.
---- Example: stbo:setRadarTrace("arrow.png") -- sets the radar trace to resources/radar/arrow.png
---- Example: ship:setRadarTrace("blip.png") -- displays a dot for this ship on radar when scanned
+--- Unscanned entities appear on player radar as their defined radar_trace.icon by default, unless radar_trace.arrow_if_not_scanned=true, in which case the entity appears as an arrow (equivalent to an argument value of "ship.png").
+--- Examples:
+--- entity:setRadarTrace("arrow.png") -- sets the radar trace for this entity to resources/radar/arrow.png
+--- entity:setRadarTrace("blip.png") -- displays a dot for this entity on radar when scanned
 function Entity:setRadarTrace(filename)
     if self.components.radar_trace then
         self.components.radar_trace.icon = "radar/" .. filename
     end
+    return self
 end
 
 --- Sets this entity's impulse engine sound effect.

--- a/scripts/api/entity/shiptemplatebasedobject.lua
+++ b/scripts/api/entity/shiptemplatebasedobject.lua
@@ -281,12 +281,12 @@ end
 --- [DEPRECATED]
 --- Use getShieldLevel() with an index value.
 function Entity:getFrontShield()
-    return self.getShieldLevel(0)
+    return self:getShieldLevel(0)
 end
 --- [DEPRECATED]
 --- Use getShieldMax() with an index value.
 function Entity:getFrontShieldMax()
-    return self.getShieldMax(0)
+    return self:getShieldMax(0)
 end
 --- [DEPRECATED]
 --- Use setShields() with an index value.
@@ -303,12 +303,12 @@ end
 --- [DEPRECATED]
 --- Use getShieldLevel() with an index value.
 function Entity:getRearShield()
-    return self.getShieldLevel(1)
+    return self:getShieldLevel(1)
 end
 --- [DEPRECATED]
 --- Use getShieldMax() with an index value.
 function Entity:getRearShieldMax()
-    return self.getShieldMax(1)
+    return self:getShieldMax(1)
 end
 --- [DEPRECATED]
 --- Use setShields() with an index value.

--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -191,6 +191,7 @@ end
 --- Requires a target player ship and message, though the message can be an empty string.
 --- Example: entity:sendCommsMessage(player, "Prepare to die")
 function Entity:sendCommsMessage(target, message)
+    -- Color values should match log_receive_friendly, _neutral, _enemy in colors.ini
     if self:isFriendly(target) then
         target:addToShipLog(message, "#C0C0FF")
     elseif self:isEnemy(target) then

--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -259,10 +259,11 @@ function Entity:setReputationPoints(amount)
 end
 --- Deducts a given number of faction reputation points from this entity.
 --- Returns true if there are enough points to deduct the specified amount, then does so.
---- Returns false if there are not enough points, then does not deduct any.
---- Example: entity:takeReputationPoints(1000) -- returns false if `obj` has fewer than 1000 reputation points, otherwise returns true and deducts the points
+--- Returns false and doesn't modify the value if there aren't enough points, or if the argument's value is negative.
+--- Example:
+--- -- Return false if `obj` has fewer than 1000 reputation points or the passed value is negative. Otherwise, return true and deduct the points.--- entity:takeReputationPoints(1000)
 function Entity:takeReputationPoints(amount)
-    if self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
+    if amount > 0 and self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
         local points = self.components.faction.entity.components.faction_info.reputation_points
         if points >= amount then
             self.components.faction.entity.components.faction_info.reputation_points = points - amount
@@ -272,13 +273,11 @@ function Entity:takeReputationPoints(amount)
     return false
 end
 --- Adds a given number of faction reputation points to this entity.
+--- Discards negative values. Returns the entity.
 --- Example: entity:addReputationPoints(1000)
 function Entity:addReputationPoints(amount)
-    if self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
-        local points = self.components.faction.entity.components.faction_info.reputation_points
-        if points >= -amount then
-            self.components.faction.entity.components.faction_info.reputation_points = points + amount
-        end
+    if amount > 0 and self.components.faction and self.components.faction.entity and self.components.faction.entity.components.faction_info then
+        self.components.faction.entity.components.faction_info.reputation_points = self.components.faction.entity.components.faction_info.reputation_points + amount
     end
     return self
 end

--- a/scripts/api/entity/spaceobject.lua
+++ b/scripts/api/entity/spaceobject.lua
@@ -28,12 +28,17 @@ function Entity:getRotation()
     if self.components.transform then return self.components.transform.rotation end
 end
 --- Sets this entity's heading, in degrees ranging from 0 to 360.
---- Unlike setRotation(), a value of 0 points to the top of the map ("north").
+--- Unlike setRotation(), a value of 0 points to the top of the map ("north"), which matches player radars.
 --- Values that are negative or greater than 360 are converted to values within that range.
 --- setHeading() and setRotation() do not change the helm's target heading on player ships. To do that, use commandTargetRotation().
 --- Example: entity:setHeading(0)
 function Entity:setHeading(heading)
-    if self.components.transform then self.components.transform.rotation = heading + 270 end
+    if self.components.transform then
+        local heading = self.components.transform.rotation + 270
+        while heading < 0 do heading = heading + 360 end
+        while heading > 360 do heading = heading - 360 end
+        self.components.transform.rotation = heading
+    end
     return self
 end
 --- Returns this entity's heading, in degrees ranging from 0 to 360.

--- a/scripts/api/entity/spaceship.lua
+++ b/scripts/api/entity/spaceship.lua
@@ -818,11 +818,11 @@ function Entity:addBroadcast(target, message)
 
         elseif not ent:isEnemy(self) and target >= 1 then
             add = true
-            color = {255, 102, 102, 255}
+            color = {128, 128, 128, 255}
 
         elseif target >= 2 then
             add = true
-            color = {128, 128, 128, 255}
+            color = {255, 102, 102, 255}
         end
 
         if add then

--- a/scripts/api/entity/spaceship.lua
+++ b/scripts/api/entity/spaceship.lua
@@ -706,7 +706,9 @@ end
 function Entity:getWeaponTubeLoadType(index)
     local tubes = self.components.missile_tubes
     local missile_type = "none"
-    if  tubes and index >= 0 and index < #tubes then missile_type = tubes[index+1].type_loaded end
+    if tubes and index >= 0 and index < #tubes then
+        missile_type = tubes[index+1].type_loaded
+    end
     if missile_type == "none" then return nil end
     return missile_type
 end
@@ -744,33 +746,48 @@ end
 --- Accepts 0, negative, and positive values.
 --- Example:
 --- -- Sets tube 0 to point 90 degrees right of forward, and tube 1 to point 90 degrees left of forward
---- ship:setWeaponTubeDirection(0,90):setWeaponTubeDirection(1,-90)
+--- ship:setWeaponTubeDirection(0, 90):setWeaponTubeDirection(1, -90)
 function Entity:setWeaponTubeDirection(index, direction)
-    if self.components.missile_tubes then self.components.missile_tubes[index+1].direction = direction end
+    local tubes = self.components.missile_tubes
+    if tubes and index >= 0 and index < #tubes then
+        self.components.missile_tubes[index+1].direction = direction
+    end
     return self
 end
 --- Sets the weapon size launched from the WeaponTube with the given index on this ship.
 --- Example: ship:setTubeSize(0,"large") -- sets tube 0 to fire large weapons
 function Entity:setTubeSize(index, size)
-    if self.components.missile_tubes then self.components.missile_tubes[index+1].size = size end
+    local tubes = self.components.missile_tubes
+    if tubes and index >= 0 and index < #tubes then
+        self.components.missile_tubes[index+1].size = size
+    end
     return self
 end
 --- Returns the size of the weapon tube with the given index on this ship.
 --- Example: ship:getTubeSize(0)
 function Entity:getTubeSize(index)
-    if self.components.missile_tubes then return self.components.missile_tubes[index+1].size end
-    return "medium"
+    local tubes = self.components.missile_tubes
+    if tubes and index >= 0 and index < #tubes then
+        return self.components.missile_tubes[index+1].size
+    end
+    return "none"
 end
 --- Returns the delay, in seconds, for loading and unloading the WeaponTube with the given index on this ship.
 --- Example: ship:getTubeLoadTime(0)
 function Entity:getTubeLoadTime(index)
-    if self.components.missile_tubes then return self.components.missile_tubes[index+1].load_time end
+    local tubes = self.components.missile_tubes
+    if tubes and index >= 0 and index < #tubes then
+        return self.components.missile_tubes[index+1].load_time
+    end
     return 0.0
 end
 --- Sets the time, in seconds, required to load the weapon tube with the given index on this ship.
 --- Example: ship:setTubeLoadTime(0,12) -- sets the loading time for tube 0 to 12 seconds
 function Entity:setTubeLoadTime(index, load_time)
-    if self.components.missile_tubes then self.components.missile_tubes[index+1].load_time = load_time end
+    local tubes = self.components.missile_tubes
+    if tubes and index >= 0 and index < #tubes then
+        self.components.missile_tubes[index+1].load_time = load_time
+    end
     return self
 end
 --- Returns the dynamic gravitational radar signature value emitted by this ship.

--- a/scripts/api/entity/supplydrop.lua
+++ b/scripts/api/entity/supplydrop.lua
@@ -20,7 +20,7 @@ function SupplyDrop()
         pickup={}
     }
     for k, v in pairs(__model_data["ammo_box"]) do
-        if string.sub(1, 2) ~= "__" then
+        if string.sub(k, 1, 2) ~= "__" then
             e.components[k] = table.deepcopy(v)
         end
     end

--- a/scripts/api/entity/warpjammer.lua
+++ b/scripts/api/entity/warpjammer.lua
@@ -18,7 +18,7 @@ function WarpJammer()
         physics = {type="static",size=300},
     }
     for k, v in pairs(__model_data["shield_generator"]) do
-        if string.sub(1, 2) ~= "__" then
+        if string.sub(k, 1, 2) ~= "__" then
             e.components[k] = table.deepcopy(v)
         end
     end

--- a/scripts/api/entity/warpjammer.lua
+++ b/scripts/api/entity/warpjammer.lua
@@ -30,7 +30,7 @@ local Entity = getLuaEntityFunctionTable()
 --- No warp/jump travel is possible within this radius.
 --- Example: jammer:getRange()
 function Entity:getRange()
-    if self.warp_jammer then return self.warp_jammer.range end
+    if self.components.warp_jammer then return self.components.warp_jammer.range end
     return 0
 end
 --- Sets this WarpJammer's jamming radius.
@@ -38,6 +38,6 @@ end
 --- Defaults to 7000.0.
 --- Example: jammer:setRange(10000) -- sets a 10U jamming radius 
 function Entity:setRange(range)
-    if self.warp_jammer then self.warp_jammer.range = range end
+    if self.components.warp_jammer then self.components.warp_jammer.range = range end
     return self
 end

--- a/scripts/api/modelData.lua
+++ b/scripts/api/modelData.lua
@@ -132,7 +132,7 @@ end
 --- If you view the model in Blender, these coordinate values are equivalent to -X,+Y,+Z.
 --- Example:
 --- -- Add a beam position at the given model X/Y/Z coordinates.
---- model:addBeamPosition(21,-28.2,-2)
+--- model:addBeamPosition(21, -28.2, -2)
 function ModelData:addBeamPosition(x, y, z)
     if self.__beam_positions == nil then self.__beam_positions = {} end
     self.__beam_positions[#self.__beam_positions + 1] = {x, y, z}
@@ -142,8 +142,8 @@ end
 --- If no origin positions are defined, this defaults to the model's origin (0,0,0).
 --- If you view the model in Blender, these coordinate values are equivalent to -X,+Y,+Z.
 --- -- Add a tube position at the given model X/Y/Z coordinates.
---- model:addTubePosition(21,-28.2,-2)
-function ModelData:addTubePosition()
+--- model:addTubePosition(21, -28.2, -2)
+function ModelData:addTubePosition(x, y, z)
     if self.__tube_positions == nil then self.__tube_positions = {} end
     self.__tube_positions[#self.__tube_positions + 1] = {x, y, z}
     return self

--- a/scripts/api/modelData.lua
+++ b/scripts/api/modelData.lua
@@ -155,19 +155,27 @@ function ModelData:addEngineEmitor(x, y, z, r, g, b, scale)
     return self:addEngineEmitter(x, y, z, r, g, b, scale)
 end
 --- Adds an impulse engine particle effect emitter to this ModelData.
---- When a ship engages impulse engines, this defines the position, color, and size of a particle trail effect.
+--- When a ship engages impulse engines, this defines the position, color, and size of particle trail effects for an engine on the ship's 3D model.
 --- If no origin positions are defined, this defaults to the model's origin (0,0,0).
+--- If no mesh scale is defined, this sets it to the MeshRender default (1.0).
 --- If you view the model in Blender, these coordinate values are equivalent to -X,+Y,+Z.
 --- Example:
---- -- Add an engine emitter at the given model X/Y/Z coordinates, with a RGB color of 1.0/0.2/0.2 and scale of 3.
---- model:addEngineEmitter(-28, 1.5,-5,1.0,0.2,0.2,3.0)
+--- -- Add an engine emitter at model X/Y/Z coordinates -28.0, 1.5, -5.0, with a RGB color of 1.0, 0.2, 0.2 and scale of 3.0.
+--- model:addEngineEmitter(-28.0, 1.5, -5.0, 1.0, 0.2, 0.2, 3.0)
 function ModelData:addEngineEmitter(x, y, z, r, g, b, scale)
     if self.engine_emitter == nil then self.engine_emitter = {} end
     if self.mesh_render then
+        -- Set mesh_render.scale to 1.0 and warn if not defined
+        if self.mesh_render.scale == nil then
+            print("addEngineEmitter() called without mesh_render.scale value; using default 1.0 for mesh_render.scale")
+            self.mesh_render.scale = 1.0
+        else
+            scale = scale * self.mesh_render.scale
+        end
+
         x = x * self.mesh_render.scale
         y = y * self.mesh_render.scale
         z = z * self.mesh_render.scale
-        scale = scale * self.mesh_render.scale
     end
     self.engine_emitter[#self.engine_emitter+1] = {position = {x, y, z}, color={r, g, b}, scale=scale}
     return self

--- a/scripts/api/shipTemplate.lua
+++ b/scripts/api/shipTemplate.lua
@@ -163,7 +163,7 @@ function ShipTemplate:setModel(model_data_name)
 
     self.__model_data_name = model_data_name
     for k, v in pairs(__model_data[model_data_name]) do
-        if string.sub(1, 2) ~= "__" then
+        if string.sub(k, 1, 2) ~= "__" then
             self[k] = table.deepcopy(v)
         end
     end

--- a/scripts/scenario_99_test_scans.lua
+++ b/scripts/scenario_99_test_scans.lua
@@ -1,0 +1,5 @@
+CpuShip():setTemplate('Adder MK9'):setPosition(-69, 4059):setRotation(320):setFaction('Independent'):orderIdle()
+CpuShip():setTemplate('Adder MK9'):setPosition(3281, -23):setRotation(395):setFaction('Independent'):orderIdle()
+CpuShip():setTemplate('Adder MK9'):setPosition(-725, -3618):setRotation(266):setFaction('Independent'):orderIdle()
+CpuShip():setTemplate('Adder MK9'):setPosition(-3947, -149):setRotation(330):setFaction('Independent'):orderIdle()
+PlayerSpaceship():setTemplate('Atlantis'):setPosition(-598, 199):setRotation(265):setFaction('Human Navy')

--- a/scripts/scenario_test_minimal.lua
+++ b/scripts/scenario_test_minimal.lua
@@ -1,0 +1,24 @@
+-- Name: Minimal Camera Test
+-- Description: Minimal test for camera feature
+-- Type: Development
+
+function init()
+    -- Create a player ship at the origin
+    player = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis")
+    player:setPosition(0, 0)
+
+    -- Create a simple camera WITHOUT assigning it to main screen
+    cam = createEntity()
+    cam.components.transform = {}
+    cam:setPosition(1000, 0)
+    cam.components.cinematic_camera = {
+        name = "Test Camera",
+        yaw = 180,
+        pitch = 30,
+        z_position = 500,
+        field_of_view = 60
+    }
+end
+
+function update(delta)
+end

--- a/src/script/enum.h
+++ b/src/script/enum.h
@@ -283,9 +283,9 @@ template<> struct Convert<DockingPort::State> {
         string str = string(luaL_checkstring(L, idx)).lower();
         if (str == "not_docking")
             return DockingPort::State::NotDocking;
-        else if (str == "opening")
+        else if (str == "docking")
             return DockingPort::State::Docking;
-        else if (str == "hailed")
+        else if (str == "docked")
             return DockingPort::State::Docked;
         luaL_error(L, "Unknown DockingPort::State: %s", str.c_str());
         return DockingPort::State::NotDocking;


### PR DESCRIPTION
- Fix broken `string.sub()` calls re: model data that forget to pass the string into the function's first argument
  - shipTemplate.lua
  - warpjammer.lua
  - artifact.lua
  - supplydrop.lua
  - scanprobe.lua
- Add missing coordinate arguments to `ModelData:addTubePosition()`
- Use the `offset_x`/`_y` arguments passed to `orderFlyFormation()` instead of invalid globals `x`/`y`
- Fix deprecated shield functions' dot/colon notation
- Fix broken ScienceDatabase `hasEntries()`, which still doesn't work as documented anyway due to daid/EmptyEpsilon#2615 / daid/EmptyEpsilon#2617
- Use `deepcopy()` to copy modelData by value for `ScienceDatabase:setModelDataName()`, aligned with other uses of `deepcopy()` for modelData
- Fix DockingPort state enum converter incorrectly using copied/pasted Comms values (use `docking` instead of `opening`, `docked` instead of `hailed`)
- Fix `setPlanetCloudRadius()`, warpjammer `get`/`setRange()` missing `components` reference
- Replace incorrect `spin` with function argument `rotation_time` in planet `setAxialRotationTime()`
- Remove unused `hailed_player` state in `isCommsBeingHailed()`
- Fix spaceship `addBroadcast()` color assignments; hostile is gray and neutral is red
- Validate tube index on spaceship `get`/`setWeaponTube...()` functions
- Fix broken value validation in spaceobject `take`/`addReputationPoints()`
- Fix function chaining in stbo `setRadarTrace()`
- Validate mesh_render.scale is present before using values in `addEngineEmitter()`
- Clamp spaceobject `getHeading()` to 0-360 range

TODO:

- Investigate potential component overwriting in playerspaceship `setCanDock()`
- Investigate potential table overwrite in shipTemplate `setEnergyStorage()`
- Investigate if shipTemplate beam functions() need to check for nil
- Investigate whether spaceship `get/setBeam...Turret()` functions use degrees per tick or second

Deferred to gn32:

- All the problems with waypoint functions