### PR TITLE
Remove ninja, freetype from macOS brew dependencies

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Dependencies
         run: |
-          brew install ninja sdl2 freetype
+          brew install sdl2
       - name: SeriousProton Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The current GitHub macOS images already include ninja and freetype